### PR TITLE
Serialize any stringable object

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -77,14 +77,14 @@ class Serializer
             return self::serializeInteger($value);
         } elseif (is_float($value)) {
             return self::serializeDecimal($value);
-        } elseif (is_string($value)) {
-            return self::serializeString($value);
-        } elseif ($value instanceof Token) {
-            return self::serializeToken($value);
         } elseif (is_bool($value)) {
             return self::serializeBoolean($value);
+        } elseif ($value instanceof Token) {
+            return self::serializeToken($value);
         } elseif ($value instanceof Bytes) {
             return self::serializeByteSequence($value);
+        } elseif (is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            return self::serializeString($value);
         }
 
         throw new SerializeException("Unrecognized type");

--- a/tests/SerializeStringTest.php
+++ b/tests/SerializeStringTest.php
@@ -15,7 +15,35 @@ class SerializeStringTest extends TestCase
     public function testInvalidCharacter()
     {
         $this->expectException(SerializeException::class);
+        $this->expectExceptionMessage("Invalid characters in string");
 
         Serializer::serializeItem("🙁");
+    }
+
+    public function testStringableObject()
+    {
+        $stringable = new class {
+            public function __toString(): string
+            {
+                return "Don't Panic";
+            }
+        };
+
+        $this->assertEquals('"Don\'t Panic"', Serializer::serializeItem($stringable));
+    }
+
+    public function testInvalidStringableObject()
+    {
+        $this->expectException(SerializeException::class);
+        $this->expectExceptionMessage("Invalid characters in string");
+
+        $stringable = new class {
+            public function __toString(): string
+            {
+                return "🙁";
+            }
+        };
+
+        Serializer::serializeItem($stringable);
     }
 }


### PR DESCRIPTION
Not sure if it should be expected behaviour to serialize any object with a `__toString` method as a string - currently it will throw a `SerializeException`

This needs to reorder the type checks, since the `Token` and `Bytes` classes are just wrappers around a string and have a `__toString` method, but I don't think the order of types in [4.1.3.1. Serializing a Bare Item](https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#ser-bare-item) is essential.